### PR TITLE
/?list=true

### DIFF
--- a/PowerVault/PowerVault.psm1
+++ b/PowerVault/PowerVault.psm1
@@ -114,7 +114,7 @@ function Get-Secret
         $AsCredential
     )
 
-    $uri = $VaultObject.uri + $Path
+    $uri = $VaultObject.uri + $Path + '/?list=true'
 
     $result = [string]::Empty
 


### PR DESCRIPTION
https://www.vaultproject.io/api-docs
The API documentation uses LIST as the HTTP verb, but you can still use GET with the ?list=true query string.